### PR TITLE
Remove 'Store' link from top nav

### DIFF
--- a/_includes/header.html.en
+++ b/_includes/header.html.en
@@ -37,9 +37,6 @@
             </li>
           </ul>
         </li>
-        <li class="navigation__link">
-          <a class="button--link" href="https://store.pueblounidopdx.org">Store</a>
-        </li>
         <li class="navigation__dropdown">
           <a class="button--link" href="about.html.en">About</a>
           <ul class="submenu">

--- a/_includes/header.html.es
+++ b/_includes/header.html.es
@@ -34,9 +34,6 @@
             </li>
           </ul>
         </li>
-        <li class="navigation__link">
-          <a class="button--link" href="https://store.pueblounidopdx.org">Tienda</a>
-        </li>
         <li class="navigation__dropdown">
           <a class="button--link" href="about.html.es">Sobre Nosotros</a>
           <ul class="submenu">


### PR DESCRIPTION
I closed our Shopify account. This PR will remove the link to the store from the top nav so users don't accidentally try to navigate to it